### PR TITLE
us-frontend: add /help route and nav

### DIFF
--- a/packages/us-frontend/help/index.html
+++ b/packages/us-frontend/help/index.html
@@ -24,16 +24,7 @@
           <span class="brand-subtitle">Base Mainnet · Attestation Portal</span>
         </div>
         <div class="nav-controls">
-          <nav class="nav-links" aria-label="Primary navigation">
-            <a class="nav-link" href="/" data-nav-link>
-              <span class="lang-block" data-lang="zh">产品总览</span>
-              <span class="lang-block" data-lang="en">Overview</span>
-            </a>
-            <a class="nav-link" href="/help" data-nav-link>
-              <span class="lang-block" data-lang="zh">帮助</span>
-              <span class="lang-block" data-lang="en">Help</span>
-            </a>
-          </nav>
+          <nav class="nav-links" aria-label="Primary navigation" data-nav-links></nav>
           <div class="language-toggle" aria-label="Language toggle">
             <span class="lang-block" data-lang="zh">语言：</span>
             <span class="lang-block" data-lang="en">Language:</span>
@@ -49,6 +40,6 @@
       <div class="help-content" data-help-root></div>
       <aside class="help-toc" data-help-toc aria-label="Help table of contents"></aside>
     </main>
-    <script type="module" src="/public/main.js"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/packages/us-frontend/index.html
+++ b/packages/us-frontend/index.html
@@ -24,16 +24,7 @@
           <span class="brand-subtitle">Base Mainnet · Attestation Portal</span>
         </div>
         <div class="nav-controls">
-          <nav class="nav-links" aria-label="Primary navigation">
-            <a class="nav-link" href="/" data-nav-link>
-              <span class="lang-block" data-lang="zh">产品总览</span>
-              <span class="lang-block" data-lang="en">Overview</span>
-            </a>
-            <a class="nav-link" href="/help" data-nav-link>
-              <span class="lang-block" data-lang="zh">帮助</span>
-              <span class="lang-block" data-lang="en">Help</span>
-            </a>
-          </nav>
+          <nav class="nav-links" aria-label="Primary navigation" data-nav-links></nav>
           <div class="language-toggle" aria-label="Language toggle">
             <span class="lang-block" data-lang="zh">语言：</span>
             <span class="lang-block" data-lang="en">Language:</span>
@@ -105,6 +96,6 @@
         </div>
       </section>
     </main>
-    <script type="module" src="/public/main.js"></script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/packages/us-frontend/src/App.tsx
+++ b/packages/us-frontend/src/App.tsx
@@ -1,0 +1,8 @@
+import { Route, type RouteDefinition } from './router';
+import { HelpPage } from './pages/Help';
+import { HomePage } from './pages/Home';
+
+export const routes: RouteDefinition[] = [
+  <Route path="/" element={<HomePage />} />,
+  <Route path="/help" element={<HelpPage />} />,
+];

--- a/packages/us-frontend/src/pages/Home.tsx
+++ b/packages/us-frontend/src/pages/Home.tsx
@@ -1,0 +1,13 @@
+import type { PageDescriptor } from '../router';
+import { initHome } from './home';
+
+export function HomePage(): PageDescriptor {
+  return {
+    id: 'home',
+    label: {
+      zh: '产品总览',
+      en: 'Overview',
+    },
+    init: initHome,
+  };
+}

--- a/packages/us-frontend/src/router.ts
+++ b/packages/us-frontend/src/router.ts
@@ -1,0 +1,48 @@
+import type { SupportedLanguage } from './utils/language';
+
+export type LocalizedText = Record<SupportedLanguage, string>;
+
+export interface AnchorDefinition {
+  id: string;
+  label: LocalizedText;
+}
+
+export interface PageDescriptor {
+  id: string;
+  label: LocalizedText;
+  init?: () => void;
+  anchors?: AnchorDefinition[];
+}
+
+export interface RouteProps {
+  path: string;
+  element: PageDescriptor;
+}
+
+export interface RouteDefinition extends PageDescriptor {
+  path: string;
+}
+
+function ensureLeadingSlash(path: string): string {
+  if (!path) {
+    return '/';
+  }
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function normalizePath(path: string): string {
+  const normalized = ensureLeadingSlash(path.trim());
+  const withoutTrailing = normalized.replace(/\/+$/, '');
+  return withoutTrailing || '/';
+}
+
+export function Route(props: RouteProps): RouteDefinition {
+  const anchors = props.element.anchors?.map((anchor) => ({ ...anchor })) ?? undefined;
+  return {
+    path: normalizePath(props.path),
+    id: props.element.id,
+    label: { ...props.element.label },
+    init: props.element.init,
+    anchors,
+  };
+}

--- a/packages/us-frontend/src/runtime/jsx-runtime.ts
+++ b/packages/us-frontend/src/runtime/jsx-runtime.ts
@@ -1,0 +1,33 @@
+// Minimal JSX runtime to allow declarative route configuration without React.
+
+type AnyProps = Record<string, unknown> | null | undefined;
+
+type ComponentType<P = AnyProps> = (props: P & { children?: unknown }) => unknown;
+
+type ElementType = string | ComponentType;
+
+function invokeComponent(type: ElementType, props: AnyProps, key: unknown) {
+  const normalizedProps = props ? { ...props } : {};
+  if (key !== undefined && key !== null) {
+    (normalizedProps as Record<string, unknown>).key = key as unknown;
+  }
+
+  if (typeof type === 'function') {
+    return type(normalizedProps as never);
+  }
+
+  return {
+    type,
+    props: normalizedProps,
+  };
+}
+
+export function jsx(type: ElementType, props: AnyProps, key?: unknown) {
+  return invokeComponent(type, props, key);
+}
+
+export const jsxs = jsx;
+
+export function Fragment(props: { children?: unknown }) {
+  return props.children ?? null;
+}

--- a/packages/us-frontend/tsconfig.json
+++ b/packages/us-frontend/tsconfig.json
@@ -6,6 +6,12 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "moduleDetection": "force",
+    "baseUrl": "./src",
+    "paths": {
+      "@runtime/*": ["runtime/*"]
+    },
+    "jsx": "react-jsx",
+    "jsxImportSource": "@runtime",
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/packages/us-frontend/vite.config.ts
+++ b/packages/us-frontend/vite.config.ts
@@ -2,6 +2,11 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@runtime': resolve(__dirname, 'src/runtime'),
+    },
+  },
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
## Summary
- add a minimal router abstraction and register the home and help views through `<Route>` entries
- enhance the help page with What/How/FAQ anchors and expose it as a route descriptor consumed by the new router
- rebuild the header navigation and tooling configuration so the SPA loads via `src/main.ts` and uses the custom JSX runtime

## Testing
- npm run build *(fails: TS2688 cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68f50dca6df48326910e20245f3bdd06