### PR TITLE
Add session refresh and retrieval endpoints to US API gateway

### DIFF
--- a/docs/03_系统架构-Architecture/03-05_美国服务器架构细化-USServerArchitecture.md
+++ b/docs/03_系统架构-Architecture/03-05_美国服务器架构细化-USServerArchitecture.md
@@ -1,0 +1,102 @@
+# 03-05 美国服务器架构细化 / US Server Architecture Details
+
+> 适用于美国节点的 LiqPass / LeverSafe 后端集群，重点强调前后端分层、数据安全与跨区域同步。文档目标是在与日本服务器协同时提供一致的交付基线。
+
+## 1. 系统概览 / System Overview
+
+- **前端栈 Frontend Stack**：React 18 + Next.js 14（App Router），结合 Tailwind CSS 与 Wagmi/Ethers.js 完成钱包交互。
+- **后端栈 Backend Stack**：Python 3.11，框架选型 FastAPI（首选）或 Django REST Framework（备选）。
+- **数据层 Data Layer**：托管式 PostgreSQL 15，采用多 schema 隔离业务数据与审计日志。
+- **部署目标 Deployment Target**：AWS（us-east-1）或 GCP（us-central1），支持 Docker/Kubernetes。
+- **对外接口 External Interfaces**：Binance 订单校验 API、日本服务器跨区同步 API、链上 RPC 节点（Base Mainnet/Sepolia）。
+
+## 2. 前端模块拆解 / Frontend Modules
+
+| 模块 Module | 关键功能 Key Features | 实现要点 Implementation Notes |
+| --- | --- | --- |
+| **产品目录 Product Catalog** | 展示保险产品、保额、费率、可用交易所 | 静态生成（SSG）+ 客户端过滤；数据来源 `/api/products` |
+| **订单管理 Orders** | 购买保单、查看状态、触发验证 | 使用 Next.js Server Actions 写入订单；乐观更新与重试提示 |
+| **帮助中心 Help Center** | FAQ、索赔流程、KYC 指引 | 从 Markdown/Notion 同步；支持站内搜索 |
+| **钱包连接 Wallet Connect** | 支持 MetaMask、WalletConnect、Coinbase Wallet | Wagmi + RainbowKit；提示链切换；签名获取用户 UID |
+| **凭证上传 Verification** | 输入 Binance API Key、上传订单截图/Tx Hash | 使用加密存储（Secret Manager）；前端校验格式；调用 `/api/verification` |
+| **申诉中心 Appeals** | 提交补充凭证、查看处理进度 | WebSocket/SSE 更新；多语言通知 |
+
+### 前端技术要点
+
+1. **App Router 路由分层**：公共页面使用 SSG/ISR，涉及用户数据的页面通过 Server Components 获取数据并在客户端渲染敏感信息前做脱敏。
+2. **钱包与账户绑定**：首次连接钱包时，调用 `/api/auth/nonce` 获取挑战信息，签名后换取 JWT；JWT 中包含 `wallet_address` 与 `binance_uid` 映射关系。
+3. **API Key 提交体验**：前端仅接受 Read-Only 权限的 Key，提交前展示权限校验结果（通过 `/api/exchange/validate-key`）。
+4. **国际化 I18N**：使用 `next-intl`，默认语言英文，支持中文/日文；依赖 cookie 记录语言偏好。
+
+## 3. 后端服务分层 / Backend Services
+
+### 3.1 核心服务
+
+- **API Gateway**：FastAPI 主应用，负责认证、请求路由、限流；提供 REST + WebSocket。
+- **Verification Worker**：基于 Celery/Redis 或 FastAPI BackgroundTasks，用于异步校验订单与撮合结果。
+- **Payment Service**：集成 Stripe/加密支付网关（Coinbase Commerce）；处理订单扣款与退款。
+- **Evidence Chain Service**：与区块链交互，负责生成链上存证 payload，调用日本节点的多签服务。
+
+### 3.2 关键接口
+
+| Endpoint | 方法 Method | 描述 Description |
+| --- | --- | --- |
+| `/api/auth/nonce` | GET | 获取签名挑战 nonce |
+| `/api/auth/session` | POST | 钱包签名换取 JWT，绑定用户资料 |
+| `/api/orders` | POST | 创建保单订单，写入数据库并触发支付流程 |
+| `/api/orders/{id}` | GET | 查询订单状态、赔付结果 |
+| `/api/verification` | POST | 提交订单凭证，异步校验并返回任务 ID |
+| `/api/appeals` | POST | 创建申诉记录，触发人工/半自动复核 |
+| `/api/exchange/validate-key` | POST | 检查 Binance API Key 权限与有效性 |
+| `/internal/sync/evidence` | POST | 与日本服务器互通链上凭证、赔付记录 |
+
+### 3.3 安全与合规
+
+- **认证**：JWT + 短期刷新令牌，所有写操作要求二次验证（钱包签名或邮件 OTP）。
+- **数据加密**：API Key 与敏感凭证使用 KMS/Secret Manager 加密存储；数据库字段级加密（pgcrypto）。
+- **审计日志**：所有关键操作写入 `audit_log` 表，并通过 CDC 流向 SIEM（如 Splunk）。
+- **限流与风控**：FastAPI 中间件 + Redis 令牌桶；对异常 IP 进行自动封禁。
+
+## 4. 数据库设计 / Database Schema
+
+### 4.1 核心表
+
+| 表 Table | 作用 Purpose | 关键字段 Key Fields |
+| --- | --- | --- |
+| `users` | 存储用户基础信息、钱包绑定关系 | `id`, `wallet_address`, `email`, `binance_uid`, `kyc_status` |
+| `products` | 保险产品定义、费率、限额 | `id`, `name`, `exchange`, `max_leverage`, `premium_rate`, `coverage_cap` |
+| `orders` | 用户购买的保单订单 | `id`, `user_id`, `product_id`, `status`, `premium_amount`, `payout_amount` |
+| `payments` | 支付记录、第三方流水号 | `id`, `order_id`, `provider`, `tx_hash`, `status`, `currency` |
+| `evidence_chain` | 存证数据、链上哈希 | `id`, `order_id`, `snapshot_uri`, `merkle_root`, `onchain_tx_hash`, `synced_to_jp` |
+| `verifications` | 订单验证任务及结果 | `id`, `order_id`, `source`, `status`, `payload`, `failure_reason` |
+| `appeals` | 申诉记录、处理流程 | `id`, `order_id`, `channel`, `status`, `handler`, `resolution_note` |
+| `audit_log` | 审计日志、操作轨迹 | `id`, `actor_id`, `action`, `target_type`, `target_id`, `metadata`, `created_at` |
+
+### 4.2 数据治理
+
+- **Schema 划分**：`core`（业务数据）、`compliance`（审计/留痕）、`analytics`（衍生报表）。
+- **备份策略**：每日全量快照 + 15 分钟增量，使用 Point-In-Time Recovery；跨区复制至 us-west-2。
+- **隐私保护**：对邮箱、手机号等字段进行哈希/脱敏存储，遵循美国隐私法规（CCPA）。
+
+## 5. 与日本服务器的协同 / JP-US Coordination
+
+1. **证据同步**：美国节点在验证完成后，将 `evidence_chain` 的 Merkle Root 与链上 Tx Hash 通过 `/internal/sync/evidence` 推送到日本服务器，确保双边可核验。
+2. **赔付触发**：当赔付条件满足时，美国服务器调用日本节点的多签合约服务；若日本节点未响应，则本地记录重试队列并提示人工介入。
+3. **故障回退**：采用消息队列（如 AWS SQS）缓存未同步的事件；日本节点恢复后进行补偿同步。
+
+## 6. 运行与监控 / Operations & Monitoring
+
+- **CI/CD**：GitHub Actions 构建 + 单元测试 → 推送 Docker Registry → Argo CD/Cloud Run 部署。
+- **监控 Observability**：Prometheus + Grafana 监控 API 延迟、任务队列积压；OpenTelemetry 追踪跨服务链路。
+- **日志 Logging**：结构化 JSON 日志接入 AWS OpenSearch；关键告警同步到 PagerDuty/Slack。
+- **合规审计**：季度渗透测试 + SOC 2 Type II 报告；日志保存 ≥ 400 天。
+
+## 7. 里程碑与下一步 / Roadmap
+
+1. **MVP（T+4 周）**：完成订单购买、Binance 验证、链上存证闭环；部署单区容灾。
+2. **Alpha（T+8 周）**：引入 Stripe 支付、申诉模块、跨区同步；完善审计日志。
+3. **Beta（T+12 周）**：多语言前端、SLA 监控、自动化赔付触发；准备外部审计与资助材料。
+
+---
+
+> 如需图表版部署拓扑或时序图，可在 `docs/_assets/architecture/` 目录追加 Draw.io / Mermaid 文件并引用本页面。

--- a/docs/README_索引-Index.md
+++ b/docs/README_索引-Index.md
@@ -17,6 +17,7 @@
   - `03-02_模块化开发路线图-ModularRoadmap.md`：微服务化演进步骤
   - `03-03_核心赔付逻辑-CorePayoutLogic.md`：风险判定与赔付流程
   - `03-04_系统安全设计要点-SecurityHighlights.md`：输入校验与安全策略
+  - `03-05_美国服务器架构细化-USServerArchitecture.md`：美国节点前后端与数据库拆解
 - **04 后端实现 (Backend)**
   - `04-01_混合部署开发思路-HybridApproach.md`：链下计算 + 链上存证混合方案
   - `04-03_OKX批量验证脚本-OKXBatchVerifier.md`：脚本逻辑与使用说明

--- a/src/services/microservices/api_gateway/main.py
+++ b/src/services/microservices/api_gateway/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request, HTTPException, Depends
+from fastapi import FastAPI, Request, HTTPException, Depends, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -6,12 +6,22 @@ import uvicorn
 import httpx
 import time
 import asyncio
-from functools import wraps
+from datetime import datetime, timedelta
+from uuid import uuid4
+from typing import Any, Dict, List, Optional
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from jose import JWTError
+from pydantic import BaseModel, Field, validator
+from web3 import Web3
 
 # 导入共享组件
 from ..common.logger import logger, audit_logger
 from ..common.config_manager import config_manager
-from ..common.message_queue import mq_client, QUEUE_VERIFICATION_REQUESTS, QUEUE_PAYOUT_REQUESTS
+from ..common.message_queue import mq_client, QUEUE_VERIFICATION_REQUESTS
+from ..common.authentication import AuthConfig, JWTManager, TokenPair
+from ..common.errors import AuthenticationError
 
 # 初始化FastAPI应用
 app = FastAPI(
@@ -39,6 +49,40 @@ SERVICES = {
     'report_generation': config_manager.get('services.report_generation.url', 'http://report_generation:8004'),
 }
 
+# 身份验证配置
+auth_secret = config_manager.get('auth.secret_key', 'dev-secret-change-me')
+auth_access_expire_minutes = config_manager.get('auth.access_token_expire_minutes', 30)
+auth_refresh_expire_days = config_manager.get('auth.refresh_token_expire_days', 7)
+auth_issuer = config_manager.get('auth.issuer')
+auth_audience = config_manager.get('auth.audience')
+if isinstance(auth_audience, str):
+    auth_audience = [auth_audience]
+
+auth_config = AuthConfig(
+    secret_key=auth_secret,
+    access_token_expire_minutes=auth_access_expire_minutes,
+    refresh_token_expire_days=auth_refresh_expire_days,
+    issuer=auth_issuer,
+    audience=auth_audience,
+)
+jwt_manager = JWTManager(auth_config)
+
+# 内存态存储，后续可替换为数据库
+nonce_store: Dict[str, Dict[str, Any]] = {}
+session_store: Dict[str, Dict[str, Any]] = {}
+orders_store: Dict[str, Dict[str, Any]] = {}
+verification_tasks_store: Dict[str, Dict[str, Any]] = {}
+appeals_store: Dict[str, Dict[str, Any]] = {}
+evidence_sync_log: List[Dict[str, Any]] = []
+
+# 并发锁，确保在多协程环境下数据安全
+nonce_lock = asyncio.Lock()
+session_lock = asyncio.Lock()
+orders_lock = asyncio.Lock()
+verification_lock = asyncio.Lock()
+appeals_lock = asyncio.Lock()
+evidence_lock = asyncio.Lock()
+
 # HTTP客户端配置
 HTTP_CLIENT_TIMEOUT = 30.0  # 30秒超时
 HTTP_CLIENT_MAX_RETRIES = 3  # 最多重试3次
@@ -52,20 +96,795 @@ http_client = httpx.AsyncClient(
 # 安全认证
 security = HTTPBearer()
 
-async def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    """验证访问令牌"""
+async def verify_token(request: Request, credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """验证访问令牌，并将用户信息附加到请求上下文"""
     token = credentials.credentials
-    
-    # 简化的令牌验证逻辑，实际应用中应连接到认证服务
-    # 例如，验证JWT令牌或查询认证服务
-    if not token or token != "valid-token":  # 示例验证
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid or missing authentication token"
+
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    try:
+        payload = jwt_manager.decode_token(token)
+    except AuthenticationError as auth_error:
+        raise HTTPException(status_code=auth_error.status_code, detail=auth_error.message) from auth_error
+    except JWTError as jwt_error:
+        raise HTTPException(status_code=401, detail="Invalid authentication token") from jwt_error
+
+    wallet_address = payload.get("wallet_address") or payload.get("sub")
+    if not wallet_address:
+        raise HTTPException(status_code=401, detail="Token missing wallet address")
+
+    normalized_address = Web3.to_checksum_address(wallet_address)
+
+    async with session_lock:
+        session = session_store.get(normalized_address)
+
+    if not session or session.get("access_token") != token:
+        raise HTTPException(status_code=401, detail="Session has expired or been revoked")
+
+    user_context = {
+        "wallet_address": normalized_address,
+        "binance_uid": session.get("binance_uid"),
+        "scopes": session.get("scopes", []),
+        "user_id": normalized_address,
+    }
+
+    request.state.user = user_context
+    return user_context
+
+
+def _build_timeline_entry(event: str, status: str, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """创建统一的时间线事件记录"""
+    return {
+        "event": event,
+        "status": status,
+        "timestamp": datetime.utcnow(),
+        "metadata": metadata or {},
+    }
+
+
+def _normalize_wallet(address: str) -> str:
+    """校验并返回标准的校验和地址"""
+    if not Web3.is_address(address):
+        raise HTTPException(status_code=400, detail="Invalid wallet address")
+    return Web3.to_checksum_address(address)
+
+
+class NonceResponse(BaseModel):
+    wallet_address: str
+    nonce: str
+    message: str
+    expires_at: datetime
+
+
+class SessionRequest(BaseModel):
+    wallet_address: str = Field(..., description="Ethereum wallet address used for authentication")
+    signature: str = Field(..., description="Signature of the issued nonce")
+    nonce: str = Field(..., description="Nonce previously issued by the server")
+    binance_uid: Optional[str] = Field(None, description="Associated Binance UID")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Optional client context metadata")
+
+    @validator("wallet_address")
+    def validate_wallet_address(cls, value: str) -> str:
+        return _normalize_wallet(value)
+
+    @validator("signature")
+    def validate_signature(cls, value: str) -> str:
+        if not value or not value.startswith("0x"):
+            raise ValueError("Signature must be a valid hex string")
+        return value
+
+
+class SessionResponse(TokenPair):
+    wallet_address: str
+    binance_uid: Optional[str] = None
+    issued_at: datetime
+
+
+class SessionRefreshRequest(BaseModel):
+    wallet_address: str = Field(..., description="Checksum wallet address of the session owner")
+    refresh_token: str = Field(..., description="Refresh token issued by the gateway")
+
+    @validator("wallet_address")
+    def validate_wallet(cls, value: str) -> str:
+        return _normalize_wallet(value)
+
+    @validator("refresh_token")
+    def validate_refresh_token(cls, value: str) -> str:
+        if not value:
+            raise ValueError("Refresh token is required")
+        return value
+
+
+class SessionRevokeResponse(BaseModel):
+    wallet_address: str
+    revoked: bool = True
+    timestamp: datetime
+
+
+class OrderTimelineEntry(BaseModel):
+    event: str
+    status: str
+    timestamp: datetime
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class OrderCreateRequest(BaseModel):
+    product_id: str = Field(..., min_length=1)
+    wallet_address: str = Field(..., description="Checksum wallet address of the purchaser")
+    exchange: str = Field(..., min_length=1)
+    premium_amount: float = Field(..., gt=0)
+    coverage_amount: float = Field(..., gt=0)
+    currency: str = Field("USDC", min_length=2, max_length=10)
+    leverage: Optional[float] = Field(None, gt=0)
+    binance_order_id: Optional[str] = Field(None, min_length=1)
+    metadata: Optional[Dict[str, Any]] = None
+
+    @validator("wallet_address")
+    def validate_wallet_address(cls, value: str) -> str:
+        return _normalize_wallet(value)
+
+    @validator("currency")
+    def normalize_currency(cls, value: str) -> str:
+        return value.upper()
+
+
+class OrderResponse(OrderCreateRequest):
+    order_id: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    verification_tasks: List[str] = []
+    appeals: List[str] = []
+    timeline: List[OrderTimelineEntry] = []
+
+
+class OrderListResponse(BaseModel):
+    orders: List[OrderResponse]
+    total: int
+
+
+class VerificationRequest(BaseModel):
+    order_id: str = Field(..., description="Order identifier")
+    binance_api_key: str = Field(..., min_length=8)
+    binance_api_secret: str = Field(..., min_length=8)
+    additional_evidence: Optional[List[str]] = Field(None, description="Supporting documents or transaction hashes")
+    note: Optional[str] = Field(None, description="Optional context provided by the customer")
+
+    @validator("binance_api_key", "binance_api_secret")
+    def validate_credentials(cls, value: str) -> str:
+        if " " in value:
+            raise ValueError("Credentials cannot contain whitespace")
+        return value
+
+
+class VerificationTaskResponse(BaseModel):
+    task_id: str
+    order_id: str
+    status: str
+    submitted_at: datetime
+
+
+class VerificationTaskDetailResponse(VerificationTaskResponse):
+    submitted_by: str
+    evidence: List[str] = []
+    note: Optional[str] = None
+
+
+class AppealRequest(BaseModel):
+    order_id: str
+    reason: str = Field(..., min_length=5)
+    attachments: Optional[List[str]] = None
+    preferred_channel: Optional[str] = Field(None, description="Email, Telegram, etc.")
+
+
+class AppealResponse(BaseModel):
+    appeal_id: str
+    order_id: str
+    status: str
+    submitted_at: datetime
+
+
+class AppealDetailResponse(AppealResponse):
+    submitted_by: str
+    reason: str
+    attachments: List[str] = []
+    preferred_channel: Optional[str] = None
+
+
+class ExchangeKeyValidationRequest(BaseModel):
+    api_key: str = Field(..., description="Binance API key")
+    api_secret: str = Field(..., description="Binance API secret")
+    passphrase: Optional[str] = Field(None, description="Optional passphrase if required by the exchange")
+    permissions: Optional[List[str]] = Field(None, description="Permissions reported by the client UI")
+
+    @validator("api_key", "api_secret")
+    def validate_not_empty(cls, value: str) -> str:
+        if not value or len(value) < 8:
+            raise ValueError("API credentials must be at least 8 characters long")
+        if any(char.isspace() for char in value):
+            raise ValueError("API credentials cannot contain whitespace")
+        return value
+
+
+class ExchangeKeyValidationResponse(BaseModel):
+    is_valid: bool
+    is_read_only: bool
+    permissions: List[str]
+    message: str
+    provider: str = "binance"
+
+
+class EvidenceSyncRequest(BaseModel):
+    order_id: str
+    merkle_root: str
+    onchain_tx_hash: str
+    snapshot_uri: Optional[str] = None
+    synced_by: Optional[str] = None
+
+
+class EvidenceSyncResponse(BaseModel):
+    event_id: str
+    order_id: str
+    status: str
+    recorded_at: datetime
+
+
+async def _cleanup_expired_nonces(current_time: datetime) -> None:
+    """清理过期的nonce，避免内存占用"""
+    async with nonce_lock:
+        expired = [nonce for nonce, record in nonce_store.items() if record["expires_at"] <= current_time]
+        for nonce in expired:
+            nonce_store.pop(nonce, None)
+
+
+async def _append_order_timeline(order_id: str, entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """向订单添加时间线事件并返回更新后的订单"""
+    async with orders_lock:
+        order = orders_store.get(order_id)
+        if not order:
+            return None
+
+        timeline = order.setdefault("timeline", [])
+        timeline.append(entry)
+        order["updated_at"] = entry["timestamp"]
+        return order
+
+
+async def _get_order_for_wallet(order_id: str, wallet_address: str) -> Optional[Dict[str, Any]]:
+    """获取属于指定钱包的订单副本"""
+    async with orders_lock:
+        order = orders_store.get(order_id)
+        if not order:
+            return None
+        if order.get("wallet_address") != wallet_address:
+            return None
+        return {**order}
+
+
+@app.get("/api/auth/nonce", response_model=NonceResponse, tags=["Authentication"])
+async def issue_nonce(wallet_address: str = Query(..., description="Wallet address requesting a login nonce")):
+    """生成登录所需的nonce，供前端发起钱包签名"""
+    normalized_address = _normalize_wallet(wallet_address)
+    await _cleanup_expired_nonces(datetime.utcnow())
+
+    nonce = uuid4().hex
+    message = f"Sign this message to authenticate with LeverageGuard: {nonce}"
+    expires_at = datetime.utcnow() + timedelta(minutes=5)
+
+    async with nonce_lock:
+        nonce_store[nonce] = {
+            "wallet_address": normalized_address,
+            "message": message,
+            "expires_at": expires_at,
+        }
+
+    logger.info(f"Issued nonce for wallet {normalized_address}")
+    return NonceResponse(wallet_address=normalized_address, nonce=nonce, message=message, expires_at=expires_at)
+
+
+@app.post("/api/auth/session", response_model=SessionResponse, tags=["Authentication"])
+async def create_session(payload: SessionRequest):
+    """校验签名并颁发访问令牌"""
+    async with nonce_lock:
+        nonce_record = nonce_store.pop(payload.nonce, None)
+
+    if not nonce_record:
+        raise HTTPException(status_code=400, detail="Nonce is invalid or has expired")
+
+    if nonce_record["wallet_address"] != payload.wallet_address:
+        raise HTTPException(status_code=400, detail="Nonce does not match wallet address")
+
+    if nonce_record["expires_at"] < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Nonce has expired")
+
+    message = encode_defunct(text=nonce_record["message"])
+    try:
+        recovered_address = Account.recover_message(message, signature=payload.signature)
+    except ValueError as exc:
+        logger.warning(f"Failed to recover address for nonce {payload.nonce}: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid wallet signature") from exc
+
+    if _normalize_wallet(recovered_address) != payload.wallet_address:
+        raise HTTPException(status_code=400, detail="Signature does not match wallet address")
+
+    scopes = ["orders:create", "verification:submit", "appeals:create"]
+    token_payload = {
+        "sub": payload.wallet_address,
+        "wallet_address": payload.wallet_address,
+        "binance_uid": payload.binance_uid,
+        "scopes": scopes,
+    }
+
+    token_pair: TokenPair = jwt_manager.create_token_pair(token_payload)
+    issued_at = datetime.utcnow()
+
+    async with session_lock:
+        session_store[payload.wallet_address] = {
+            "access_token": token_pair.access_token,
+            "refresh_token": token_pair.refresh_token,
+            "binance_uid": payload.binance_uid,
+            "scopes": scopes,
+            "metadata": payload.metadata or {},
+            "issued_at": issued_at,
+        }
+
+    audit_logger.log_event(
+        event_type="USER_LOGIN",
+        user_id=payload.wallet_address,
+        details={"method": "wallet_signature"},
+        metadata={"binance_uid": payload.binance_uid},
+    )
+
+    return SessionResponse(
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        expires_in=token_pair.expires_in,
+        refresh_expires_in=token_pair.refresh_expires_in,
+        wallet_address=payload.wallet_address,
+        binance_uid=payload.binance_uid,
+        issued_at=issued_at,
+    )
+
+
+@app.post("/api/auth/session/refresh", response_model=SessionResponse, tags=["Authentication"])
+async def refresh_session(payload: SessionRefreshRequest):
+    """刷新会话令牌，维持登录状态"""
+    normalized_address = payload.wallet_address
+
+    async with session_lock:
+        session = session_store.get(normalized_address)
+
+    if not session or session.get("refresh_token") != payload.refresh_token:
+        raise HTTPException(status_code=401, detail="Refresh token is invalid or has been rotated")
+
+    try:
+        refresh_payload = jwt_manager.decode_token(payload.refresh_token)
+    except AuthenticationError as auth_error:
+        raise HTTPException(status_code=auth_error.status_code, detail=auth_error.message) from auth_error
+    except JWTError as jwt_error:
+        raise HTTPException(status_code=401, detail="Invalid refresh token") from jwt_error
+
+    token_type = refresh_payload.get("type")
+    if token_type != "refresh":
+        raise HTTPException(status_code=401, detail="Provided token is not a refresh token")
+
+    refresh_subject = refresh_payload.get("sub") or refresh_payload.get("wallet_address")
+    if not refresh_subject:
+        raise HTTPException(status_code=401, detail="Refresh token subject does not match session")
+
+    try:
+        subject_normalized = _normalize_wallet(refresh_subject)
+    except HTTPException as exc:
+        raise HTTPException(status_code=401, detail="Refresh token subject does not match session") from exc
+
+    if subject_normalized != normalized_address:
+        raise HTTPException(status_code=401, detail="Refresh token subject does not match session")
+
+    scopes = session.get("scopes", [])
+    binance_uid = session.get("binance_uid")
+    new_payload = {
+        "sub": normalized_address,
+        "wallet_address": normalized_address,
+        "binance_uid": binance_uid,
+        "scopes": scopes,
+    }
+
+    token_pair = jwt_manager.create_token_pair(new_payload)
+    issued_at = datetime.utcnow()
+
+    async with session_lock:
+        session_store[normalized_address] = {
+            **session,
+            "access_token": token_pair.access_token,
+            "refresh_token": token_pair.refresh_token,
+            "issued_at": issued_at,
+        }
+
+    audit_logger.log_event(
+        event_type="USER_SESSION_REFRESHED",
+        user_id=normalized_address,
+        details={"scopes": scopes},
+        metadata={"binance_uid": binance_uid},
+    )
+
+    return SessionResponse(
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        expires_in=token_pair.expires_in,
+        refresh_expires_in=token_pair.refresh_expires_in,
+        wallet_address=normalized_address,
+        binance_uid=binance_uid,
+        issued_at=issued_at,
+    )
+
+
+@app.post("/api/auth/session/revoke", response_model=SessionRevokeResponse, tags=["Authentication"], dependencies=[Depends(verify_token)])
+async def revoke_session(request: Request):
+    """注销当前用户的会话"""
+    user = getattr(request.state, "user", {})
+    wallet_address = user.get("wallet_address")
+    if not wallet_address:
+        raise HTTPException(status_code=400, detail="Missing wallet context")
+
+    async with session_lock:
+        session_store.pop(wallet_address, None)
+
+    audit_logger.log_event(
+        event_type="USER_LOGOUT",
+        user_id=wallet_address,
+        details={},
+    )
+
+    return SessionRevokeResponse(wallet_address=wallet_address, revoked=True, timestamp=datetime.utcnow())
+
+
+@app.post("/api/orders", response_model=OrderResponse, tags=["Orders"])
+async def create_order(order: OrderCreateRequest, user: Dict[str, Any] = Depends(verify_token)):
+    """创建新的保单订单并推送到验证队列"""
+    now = datetime.utcnow()
+    order_id = uuid4().hex
+    timeline_entry = _build_timeline_entry(
+        event="order_created",
+        status="pending_verification",
+        metadata={"submitted_by": user["wallet_address"]},
+    )
+
+    order_record = {
+        **order.dict(),
+        "order_id": order_id,
+        "status": "pending_verification",
+        "created_at": now,
+        "updated_at": now,
+        "verification_tasks": [],
+        "appeals": [],
+        "timeline": [timeline_entry],
+    }
+
+    async with orders_lock:
+        orders_store[order_id] = order_record
+
+    try:
+        mq_client.publish_message(
+            QUEUE_VERIFICATION_REQUESTS,
+            {
+                "order_id": order_id,
+                "wallet_address": order.wallet_address,
+                "product_id": order.product_id,
+                "exchange": order.exchange,
+                "premium_amount": order.premium_amount,
+                "coverage_amount": order.coverage_amount,
+                "metadata": order.metadata or {},
+            },
         )
-    
-    # 返回用户信息
-    return {"user_id": "user-123", "roles": ["user"]}  # 示例用户信息
+    except Exception as exc:
+        logger.warning(f"Failed to enqueue order {order_id} for verification: {exc}")
+
+    audit_logger.log_event(
+        event_type="ORDER_CREATED",
+        user_id=user["wallet_address"],
+        details={
+            "order_id": order_id,
+            "product_id": order.product_id,
+            "exchange": order.exchange,
+        },
+        metadata=order.metadata or {},
+    )
+
+    return OrderResponse(**order_record)
+
+
+@app.get("/api/orders", response_model=OrderListResponse, tags=["Orders"])
+async def list_orders(
+    status: Optional[str] = Query(None, description="Filter by order status"),
+    limit: int = Query(25, ge=1, le=100, description="Maximum number of orders to return"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    user: Dict[str, Any] = Depends(verify_token),
+):
+    """列出当前钱包的订单"""
+    normalized_address = user["wallet_address"]
+
+    async with orders_lock:
+        owned_orders = [
+            {**order}
+            for order in orders_store.values()
+            if order.get("wallet_address") == normalized_address
+            and (status is None or order.get("status") == status)
+        ]
+
+    owned_orders.sort(key=lambda item: item.get("created_at", datetime.min), reverse=True)
+
+    sliced = owned_orders[offset : offset + limit]
+    response_orders = [OrderResponse(**order) for order in sliced]
+    return OrderListResponse(orders=response_orders, total=len(owned_orders))
+
+
+@app.get("/api/orders/{order_id}/timeline", response_model=List[OrderTimelineEntry], tags=["Orders"])
+async def get_order_timeline(order_id: str, user: Dict[str, Any] = Depends(verify_token)):
+    """查看订单的时间线事件"""
+    order = await _get_order_for_wallet(order_id, user["wallet_address"])
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    timeline_entries = order.get("timeline", [])
+    return [
+        entry if isinstance(entry, OrderTimelineEntry) else OrderTimelineEntry(**entry)
+        for entry in timeline_entries
+    ]
+
+
+@app.get("/api/orders/{order_id}/appeals", response_model=List[AppealDetailResponse], tags=["Appeals"])
+async def list_order_appeals(order_id: str, user: Dict[str, Any] = Depends(verify_token)):
+    """列出订单相关的所有申诉"""
+    order = await _get_order_for_wallet(order_id, user["wallet_address"])
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    appeal_ids = order.get("appeals", [])
+    async with appeals_lock:
+        appeals = [
+            AppealDetailResponse(**record)
+            for appeal_id in appeal_ids
+            if (record := appeals_store.get(appeal_id))
+        ]
+
+    appeals.sort(key=lambda entry: entry.submitted_at, reverse=True)
+    return appeals
+
+
+@app.get("/api/verification", response_model=List[VerificationTaskDetailResponse], tags=["Order Verification"])
+async def list_verification_tasks(user: Dict[str, Any] = Depends(verify_token)):
+    """列出当前用户提交的所有验证任务"""
+    normalized_address = user["wallet_address"]
+
+    async with verification_lock:
+        tasks = [
+            VerificationTaskDetailResponse(**task)
+            for task in verification_tasks_store.values()
+            if task.get("submitted_by") == normalized_address
+        ]
+
+    tasks.sort(key=lambda task: task.submitted_at, reverse=True)
+    return tasks
+
+
+@app.get(
+    "/api/verification/{task_id}",
+    response_model=VerificationTaskDetailResponse,
+    tags=["Order Verification"],
+)
+async def get_verification_task(task_id: str, user: Dict[str, Any] = Depends(verify_token)):
+    """查看单个验证任务的状态"""
+    async with verification_lock:
+        task = verification_tasks_store.get(task_id)
+
+    if not task or task.get("submitted_by") != user["wallet_address"]:
+        raise HTTPException(status_code=404, detail="Verification task not found")
+
+    return VerificationTaskDetailResponse(**task)
+
+
+@app.get("/api/orders/{order_id}", response_model=OrderResponse, tags=["Orders"])
+async def get_order(order_id: str, user: Dict[str, Any] = Depends(verify_token)):
+    """查询订单状态"""
+    order = await _get_order_for_wallet(order_id, user["wallet_address"])
+
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    logger.info(f"Order {order_id} retrieved by {user['wallet_address']}")
+
+    return OrderResponse(**order)
+
+
+@app.post("/api/verification", response_model=VerificationTaskResponse, tags=["Order Verification"])
+async def submit_verification(payload: VerificationRequest, user: Dict[str, Any] = Depends(verify_token)):
+    """提交订单验证请求"""
+    async with orders_lock:
+        order = orders_store.get(payload.order_id)
+
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    task_id = uuid4().hex
+    submitted_at = datetime.utcnow()
+    task_record = {
+        "task_id": task_id,
+        "order_id": payload.order_id,
+        "status": "received",
+        "submitted_at": submitted_at,
+        "submitted_by": user["wallet_address"],
+        "evidence": payload.additional_evidence or [],
+        "note": payload.note,
+    }
+
+    async with verification_lock:
+        verification_tasks_store[task_id] = task_record
+
+    async with orders_lock:
+        order = orders_store.get(payload.order_id)
+        if order:
+            order.setdefault("verification_tasks", []).append(task_id)
+            order["status"] = "under_review"
+            order.setdefault("timeline", []).append(
+                _build_timeline_entry(
+                    event="verification_submitted",
+                    status="under_review",
+                    metadata={"task_id": task_id, "submitted_by": user["wallet_address"]},
+                )
+            )
+            order["updated_at"] = submitted_at
+
+    try:
+        mq_client.publish_message(
+            QUEUE_VERIFICATION_REQUESTS,
+            {
+                "task_id": task_id,
+                "order_id": payload.order_id,
+                "binance_api_key": payload.binance_api_key,
+                "binance_api_secret": payload.binance_api_secret,
+                "additional_evidence": payload.additional_evidence or [],
+                "note": payload.note,
+            },
+        )
+    except Exception as exc:
+        logger.warning(f"Failed to enqueue verification task {task_id}: {exc}")
+
+    audit_logger.log_event(
+        event_type="VERIFICATION_SUBMITTED",
+        user_id=user["wallet_address"],
+        details={"order_id": payload.order_id, "task_id": task_id},
+    )
+
+    return VerificationTaskResponse(task_id=task_id, order_id=payload.order_id, status="received", submitted_at=submitted_at)
+
+
+@app.post("/api/appeals", response_model=AppealResponse, tags=["Appeals"])
+async def submit_appeal(payload: AppealRequest, user: Dict[str, Any] = Depends(verify_token)):
+    """提交申诉信息，供人工或半自动流程处理"""
+    async with orders_lock:
+        order = orders_store.get(payload.order_id)
+
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    appeal_id = uuid4().hex
+    submitted_at = datetime.utcnow()
+    appeal_record = {
+        "appeal_id": appeal_id,
+        "order_id": payload.order_id,
+        "status": "pending",
+        "submitted_at": submitted_at,
+        "submitted_by": user["wallet_address"],
+        "reason": payload.reason,
+        "attachments": payload.attachments or [],
+        "preferred_channel": payload.preferred_channel,
+    }
+
+    async with appeals_lock:
+        appeals_store[appeal_id] = appeal_record
+
+    async with orders_lock:
+        order = orders_store.get(payload.order_id)
+        if order:
+            order.setdefault("appeals", []).append(appeal_id)
+            order.setdefault("timeline", []).append(
+                _build_timeline_entry(
+                    event="appeal_submitted",
+                    status="appeal_pending",
+                    metadata={"appeal_id": appeal_id, "submitted_by": user["wallet_address"]},
+                )
+            )
+            order["updated_at"] = submitted_at
+
+    audit_logger.log_event(
+        event_type="APPEAL_SUBMITTED",
+        user_id=user["wallet_address"],
+        details={"order_id": payload.order_id, "appeal_id": appeal_id},
+        metadata={"preferred_channel": payload.preferred_channel},
+    )
+
+    return AppealResponse(appeal_id=appeal_id, order_id=payload.order_id, status="pending", submitted_at=submitted_at)
+
+
+@app.post("/api/exchange/validate-key", response_model=ExchangeKeyValidationResponse, tags=["Exchange"])
+async def validate_exchange_key(payload: ExchangeKeyValidationRequest, user: Dict[str, Any] = Depends(verify_token)):
+    """对用户提交的Binance API Key进行基础格式校验"""
+    detected_permissions = [perm.lower() for perm in (payload.permissions or [])]
+
+    read_only_indicators = {"read", "read_only", "read-only", "query"}
+    is_read_only = bool(detected_permissions) and all(perm in read_only_indicators for perm in detected_permissions)
+
+    if not detected_permissions:
+        # 简单启发式：密钥以 "ro" 开头视为只读
+        is_read_only = payload.api_key.lower().startswith("ro")
+
+    message = "API key format is valid"
+    if not is_read_only:
+        message = "API key should be scoped to read-only permissions"
+
+    audit_logger.log_event(
+        event_type="EXCHANGE_KEY_VALIDATED",
+        user_id=user["wallet_address"],
+        details={"is_read_only": is_read_only},
+        metadata={"permissions": detected_permissions or []},
+    )
+
+    return ExchangeKeyValidationResponse(
+        is_valid=True,
+        is_read_only=is_read_only,
+        permissions=detected_permissions or (["read_only"] if is_read_only else []),
+        message=message,
+    )
+
+
+@app.post("/internal/sync/evidence", response_model=EvidenceSyncResponse, tags=["Internal"])
+async def record_evidence_sync(payload: EvidenceSyncRequest, user: Dict[str, Any] = Depends(verify_token)):
+    """记录与日本节点同步的链上证据信息"""
+    async with orders_lock:
+        if payload.order_id not in orders_store:
+            raise HTTPException(status_code=404, detail="Order not found")
+
+    event_id = uuid4().hex
+    recorded_at = datetime.utcnow()
+    record = {
+        "event_id": event_id,
+        "order_id": payload.order_id,
+        "merkle_root": payload.merkle_root,
+        "onchain_tx_hash": payload.onchain_tx_hash,
+        "snapshot_uri": payload.snapshot_uri,
+        "synced_by": payload.synced_by or user.get("wallet_address"),
+        "recorded_at": recorded_at,
+    }
+
+    async with evidence_lock:
+        evidence_sync_log.append(record)
+
+    await _append_order_timeline(
+        payload.order_id,
+        _build_timeline_entry(
+            event="evidence_synced",
+            status="synced",
+            metadata={
+                "event_id": event_id,
+                "merkle_root": payload.merkle_root,
+                "onchain_tx_hash": payload.onchain_tx_hash,
+            },
+        ),
+    )
+
+    audit_logger.log_event(
+        event_type="EVIDENCE_SYNC_RECORDED",
+        user_id=user.get("wallet_address"),
+        details={
+            "order_id": payload.order_id,
+            "event_id": event_id,
+            "merkle_root": payload.merkle_root,
+            "onchain_tx_hash": payload.onchain_tx_hash,
+        },
+    )
+
+    return EvidenceSyncResponse(event_id=event_id, order_id=payload.order_id, status="recorded", recorded_at=recorded_at)
 
 # 请求计时和日志中间件
 @app.middleware("http")
@@ -96,8 +915,10 @@ async def log_request_middleware(request: Request, call_next):
             user_id = "anonymous"
             # 尝试从请求中获取用户信息
             if hasattr(request.state, "user"):
-                user_id = request.state.user.get("user_id", "anonymous")
-            
+                user_info = getattr(request.state, "user", {})
+                if isinstance(user_info, dict):
+                    user_id = user_info.get("user_id") or user_info.get("wallet_address", "anonymous")
+
             audit_logger.log_api_request(
                 user_id=user_id,
                 endpoint=path,


### PR DESCRIPTION
## Summary
- add refresh and revoke session endpoints while enriching the request context with wallet-bound user identifiers
- provide authenticated order listing, timeline, appeal, and verification task retrieval APIs scoped to the requesting wallet
- introduce helpers for wallet ownership checks to back the new read endpoints

## Testing
- python -m compileall src/services/microservices/api_gateway/main.py

------
https://chatgpt.com/codex/tasks/task_e_68f644474fd08326a446d6477b33b454