### PR TITLE
fix(frontend): normalize nested premiumUSDC payloads

### DIFF
--- a/apps/us-frontend/src/lib/premiumUSDCTransform.spec.ts
+++ b/apps/us-frontend/src/lib/premiumUSDCTransform.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePremiumUSDCFields } from './premiumUSDCTransform.ts';
+
+describe('normalizePremiumUSDCFields', () => {
+  it('should convert premiumUSDC fields recursively', () => {
+    const payload = {
+      premiumUSDC: 0.5,
+      nested: {
+        premiumUSDC: '1.25',
+        deeper: [{ premiumUSDC: 0.01 }, { unrelated: true }],
+      },
+      list: [
+        { premiumUSDC: 2 },
+        {
+          child: {
+            premiumUSDC: '0.123456',
+          },
+        },
+      ],
+    };
+
+    const result = normalizePremiumUSDCFields(structuredClone(payload));
+
+    expect(result).toEqual({
+      premiumUSDC_6d: '500000',
+      nested: {
+        premiumUSDC_6d: '1250000',
+        deeper: [
+          { premiumUSDC_6d: '10000' },
+          { unrelated: true },
+        ],
+      },
+      list: [
+        { premiumUSDC_6d: '2000000' },
+        {
+          child: {
+            premiumUSDC_6d: '123456',
+          },
+        },
+      ],
+    });
+  });
+
+  it('should remove premiumUSDC when premiumUSDC_6d already exists', () => {
+    const payload = {
+      premiumUSDC: 1,
+      premiumUSDC_6d: 2500000,
+      nested: {
+        premiumUSDC: '3.5',
+        premiumUSDC_6d: '4000000',
+      },
+    };
+
+    const result = normalizePremiumUSDCFields(structuredClone(payload));
+
+    expect(result).toEqual({
+      premiumUSDC_6d: '2500000',
+      nested: {
+        premiumUSDC_6d: '4000000',
+      },
+    });
+  });
+
+  it('should leave non-object values untouched', () => {
+    expect(normalizePremiumUSDCFields('test')).toBe('test');
+    expect(normalizePremiumUSDCFields(123 as any)).toBe(123);
+    expect(normalizePremiumUSDCFields(null as any)).toBeNull();
+  });
+});

--- a/apps/us-frontend/src/lib/premiumUSDCTransform.ts
+++ b/apps/us-frontend/src/lib/premiumUSDCTransform.ts
@@ -1,0 +1,54 @@
+import { toUSDC6d } from './usdcUtils.ts';
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * 递归地遍历对象/数组，将 premiumUSDC 字段转换为 premiumUSDC_6d 字符串。
+ * 会在原地修改传入的数据结构，并删除所有 premiumUSDC 字段。
+ */
+export function normalizePremiumUSDCFields<T extends JsonValue>(payload: T): T {
+  return transformPremiumUSDC(payload) as T;
+}
+
+function transformPremiumUSDC(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      value[i] = transformPremiumUSDC(value[i]);
+    }
+    return value;
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, JsonValue>;
+
+    if (Object.prototype.hasOwnProperty.call(record, 'premiumUSDC')) {
+      if (!Object.prototype.hasOwnProperty.call(record, 'premiumUSDC_6d')) {
+        record.premiumUSDC_6d = String(toUSDC6d(record.premiumUSDC as number | string));
+      }
+      delete record.premiumUSDC;
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(record, 'premiumUSDC_6d') &&
+      record.premiumUSDC_6d !== undefined &&
+      record.premiumUSDC_6d !== null &&
+      typeof record.premiumUSDC_6d !== 'string'
+    ) {
+      record.premiumUSDC_6d = String(record.premiumUSDC_6d as string | number | boolean);
+    }
+
+    for (const key of Object.keys(record)) {
+      record[key] = transformPremiumUSDC(record[key]);
+    }
+
+    return record;
+  }
+
+  return value;
+}

--- a/apps/us-frontend/src/services/api.ts
+++ b/apps/us-frontend/src/services/api.ts
@@ -4,7 +4,7 @@
  */
 
 import { getEnv } from '../env.ts';
-import { toUSDC6d } from '../lib/usdcUtils.ts';
+import { normalizePremiumUSDCFields } from '../lib/premiumUSDCTransform.ts';
 
 // API响应类型定义
 export interface ApiResponse<T = any> {
@@ -193,12 +193,8 @@ class ApiService {
     if (finalConfig.body && typeof finalConfig.body === 'string') {
       try {
         const body = JSON.parse(finalConfig.body);
-        // 如果请求体包含premiumUSDC字段，转换为premiumUSDC_6d
-        if (body.premiumUSDC !== undefined && body.premiumUSDC_6d === undefined) {
-          body.premiumUSDC_6d = String(toUSDC6d(body.premiumUSDC));
-          delete body.premiumUSDC; // 删除旧字段
-          finalConfig.body = JSON.stringify(body);
-        }
+        const transformed = normalizePremiumUSDCFields(body);
+        finalConfig.body = JSON.stringify(transformed);
       } catch (e) {
         // 如果解析失败，保持原样
       }


### PR DESCRIPTION
## Summary
- add a reusable helper to recursively convert premiumUSDC fields into premiumUSDC_6d strings
- wire the normalizer into the ApiService request pipeline so nested payloads are converted before sending
- cover the recursive conversion logic with a focused Vitest spec

## Testing
- pnpm --filter liqpass-frontend test:unit -- src/lib/premiumUSDCTransform.spec.ts *(fails: `vitest` binary unavailable in PATH)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691291bb13708326b84acfed23762a96)